### PR TITLE
fix: prevent hero feature cards from clipping on shorter viewports

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -22,7 +22,10 @@ function Home() {
   return (
     <div className="-mt-16">
       {/* Hero Section - Full Screen Background */}
-      <div className="relative min-h-screen md:h-screen overflow-hidden">
+      {/* min-h-screen (not a fixed h-screen) so the hero grows with its content
+          on shorter viewports instead of clipping the feature cards at the
+          section's bottom edge. overflow-hidden still contains the scaled bg. */}
+      <div className="relative min-h-screen overflow-hidden">
         <img 
           src="/annie-spratt-9VpI3gQ1iUo-unsplash.jpg" 
           alt="" 


### PR DESCRIPTION
## Problem
On the landing page, the hero section used `min-h-screen md:h-screen overflow-hidden`,
which pinned it to exactly 100vh on md+ screens and clipped any overflow. When the
heading, intro, buttons, and three feature cards (Location Based / Real-time / Community)
were taller than the viewport (common on laptop and tablet heights), the cards were
sliced off right at the section's bottom edge, overlapping the "How it works" boundary line.

## Fix
Use `min-h-screen` on all breakpoints so the hero grows with its content and the page
scrolls instead of clipping. The full-screen hero look is preserved on tall viewports
(min-height still resolves to 100vh, so no change on large desktops), and `overflow-hidden`
still contains the scaled and blurred background image.

One line changed in `src/pages/Home.js`.

## Verification
Ran the app locally (`npm start`) and checked the hero across widths and heights using the
DevTools device toolbar:
- Laptop and tablet heights (where the clipping showed): cards now sit fully inside the hero
  with space above the "How it works" border, and the page scrolls.
- Full desktop: hero still fills one screen, no regression.
- Mobile: cards stack and the hero grows as before.
